### PR TITLE
Fix gir's lookup in Windows

### DIFF
--- a/bindinate/bindinate.in
+++ b/bindinate/bindinate.in
@@ -97,7 +97,7 @@ fi
 
 find_gir () {
     OLDIFS="$IFS"
-    IFS=':'; export IFS;
+    IFS='@PATH_SEPARATOR@'; export IFS;
     for dir in $2; do
         TMPGIRFILE="$dir/$1.gir"
         if [ -e "$TMPGIRFILE" ]; then
@@ -108,7 +108,7 @@ find_gir () {
     IFS=$OLDIFS; export IFS
 }
 
-GIRDIRS=$GI_TYPELIB_PATH:@GIRDIR@
+GIRDIRS=$GI_TYPELIB_PATH@PATH_SEPARATOR@@GIRDIR@
 FULLGIRFILE=$(find_gir "$GIRFILE" "$GIRDIRS")
 
 if [ x$FULLGIRFILE == x ]; then

--- a/meson.build
+++ b/meson.build
@@ -40,6 +40,13 @@ if xsltproc.found() and pkgconfig.found()
     cdata.set_quoted('prefix', get_option('prefix'))
     cdata.set_quoted('GAPIFIXUP', gapi_fixup.full_path())
 
+    if host_machine.system() == 'windows'
+        pathsep = ';'
+    else
+        pathsep = ':'
+    endif
+    cdata.set_quoted('PATH_SEPARATOR', pathsep)
+
     configure_file(output : 'bindinate', input: 'bindinate/bindinate.in', configuration : cdata)
 
     cdata = configuration_data()


### PR DESCRIPTION
Use the correct path separator in Winddows to split GI_TYPELIB_PATH dirs