### PR TITLE
Fix array types parsing

### DIFF
--- a/bindinate/gir2gapi.xslt.in
+++ b/bindinate/gir2gapi.xslt.in
@@ -1074,6 +1074,9 @@
 					<xsl:with-param name="deprecated" select="@deprecated"/>
 					<xsl:with-param name="deprecated-version" select="@deprecated-version"/>
 				</xsl:call-template>
+				<xsl:call-template name="output-element-type">
+					<xsl:with-param name="atype" select="gir:type/gir:type/@name"/>
+				</xsl:call-template>
 			</property>
 		</xsl:if>
 		
@@ -1085,6 +1088,32 @@
 
 
 	<!-- Helper templates -->
+	<xsl:template name="output-element-type">
+		<xsl:param name="atype"/>
+		<xsl:if test="$atype">
+			<xsl:variable name="merged">
+				<xsl:for-each select="$atype">
+					<xsl:variable name="rtype">
+						<xsl:choose>
+							<xsl:when test="exsl:node-set($typemappings)/mappings/mapping[@from=current()]">
+								<xsl:value-of select="exsl:node-set($typemappings)/mappings/mapping[@from=current()]/@to"/>
+							</xsl:when>
+							<xsl:otherwise>
+								<xsl:value-of select="current()"/>
+							</xsl:otherwise>
+						</xsl:choose>
+					</xsl:variable>
+					<xsl:choose>
+						<xsl:when test="position() = 1"><xsl:value-of select="$rtype"/></xsl:when>
+						<xsl:otherwise>;<xsl:value-of select="$rtype"/></xsl:otherwise>
+					</xsl:choose>
+				</xsl:for-each>
+			</xsl:variable>
+			<xsl:attribute name="element_type">
+				<xsl:value-of select="$merged"/>
+			</xsl:attribute>
+		</xsl:if>
+	</xsl:template>
 
 	<xsl:template name="output-method">
 		<xsl:param name="shared">false</xsl:param>
@@ -1349,6 +1378,9 @@
 					</xsl:if>
 				</xsl:otherwise>
 			</xsl:choose>
+			<xsl:call-template name="output-element-type">
+				<xsl:with-param name="atype" select="gir:array/gir:type/@name"/>
+			</xsl:call-template>
 		</xsl:if>
 
 


### PR DESCRIPTION
Fix array types parsing by adding `element_type` for return values and method arguments. 